### PR TITLE
ICM-139 Explicit Docker image version and name in the init script

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -208,6 +208,17 @@ define docker::run(
     $sanitised_after_array = regsubst($after_array, '[^0-9A-Za-z.\-]', '-', 'G')
   }
 
+  if (':' in $image) and !('@' in $image) {
+    # tag (version) usage
+    $image_tokens = split($image, ':')
+    $image_name = $image_tokens[0]
+    $image_version = $image_tokens[1]
+  } else {
+    # we leave Docker client to deal with it
+    $image_name = $image
+    $image_version = ''
+  }
+
   if $restart {
 
     $cidfile = "/var/run/${service_prefix}${sanitised_title}.cid"
@@ -234,6 +245,8 @@ define docker::run(
           ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
           $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template = 'docker/etc/systemd/system/docker-run.erb'
+          $docker_version_script = "/etc/systemd/system/docker-${sanitised_title}-version.sh"
+          $docker_version_template = 'docker/etc/systemd/system/docker-version.erb'
           $uses_systemd = true
           $mode = '0644'
         } else {
@@ -297,6 +310,15 @@ define docker::run(
 
     }
     else {
+
+      if $uses_systemd {
+        file { $docker_version_script:
+          ensure  => present,
+          content => template($docker_version_template),
+          mode    => '0755',
+        }
+      }
+
       file { $initscript:
         ensure  => present,
         content => template($init_template),

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -55,6 +55,23 @@ else
     }
 fi
 
+image_name="<%= @image_name %>"
+image_version="<%= @image_version %>"
+version_override_file="/etc/tradeshift/<%= @sanitised_title %>/VERSION_OVERRIDE"
+
+if [ -r $version_override_file ]
+ then
+  . $version_override_file
+  [ -n "$VERSION" ] && image_version="${VERSION}"
+fi
+
+if [ -n "${image_version}" ]
+then
+  image="${image_name}:${image_version}"
+else
+  image="${image_name}"
+fi
+
 export HOME=/root/
 docker="/usr/bin/<%= @docker_command %>"
 prog="<%= @service_prefix %><%= @sanitised_title %>"
@@ -83,17 +100,17 @@ start() {
         $docker create \
         <%= @docker_run_flags %> \
         --name <%= @sanitised_title %> \
-        <%= @image %> \
+        $image\
         <% if @command %> <%= @command %><% end %>
     <% end -%>
     <% if @pull_on_start -%>
-        $docker pull <%= @image %>
+        $docker pull $image
     <% end -%>
     <% if @remove_container_on_stop -%>
     $docker run \
     <%= @docker_run_flags %> \
     --name <%= @sanitised_title %> \
-    <%= @image %> \
+    $image \
     <% if @command %> <%= @command %><% end %>
     <% else %>
     $docker start -a <%= @sanitised_title %>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -23,6 +23,9 @@ StartLimitInterval=20
 StartLimitBurst=5
 TimeoutStartSec=0
 Environment="HOME=/root"
+
+ExecStartPre=-<%= @docker_version_script %>
+
 <%- if @before_start %>ExecStartPre=-<%= @before_start %>
 <% end -%>
 ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
@@ -30,18 +33,18 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 <% else %>ExecStartPre=-/usr/bin/<%= @docker_command %> create \
     <%= @docker_run_flags %> \
     --name <%= @sanitised_title %> \
-    <%= @image %> \
+    ${image} \
     <% if @command %> <%= @command %><% end %>
 <% end -%>
 <% @extra_systemd_parameters.each do |key, value| -%><%= key %>=<%= value %>
 <% end -%>
-<%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull <%= @image %>
+<%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull ${image}
 <% end -%>
 <%- if @remove_container_on_start %>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <%= @docker_run_flags %> \
         --name <%= @sanitised_title %> \
-        <%= @image %> \
+        ${image} \
         <% if @command %> <%= @command %><% end %>
 <% else %>
 ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>

--- a/templates/etc/systemd/system/docker-version.erb
+++ b/templates/etc/systemd/system/docker-version.erb
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+image_name="<%= @image_name %>"
+image_version="<%= @image_version %>"
+component_etc_dir="/etc/tradeshift/<%= @sanitised_title %>"
+version_override_file="${component_etc_dir}/VERSION_OVERRIDE"
+systemctl_bin="$(which systemctl)"
+
+if [ -r $version_override_file ]
+ then
+  . $version_override_file
+  [ -n "$VERSION" ] && image_version="${VERSION}"
+fi
+
+if [ -n "${image_version}" ]
+ then
+  $systemctl_bin set-environment image="${image_name}:${image_version}"
+else
+  $systemctl_bin set-environment image="${image_name}"
+fi


### PR DESCRIPTION
Currently, the Docker initscript has the image version and name in multiple parts of the code.
In order to make it easier to create the ZDD rollback job, we want to centralize it in a variable
that could, in the near future, be read from a file (one file per component).