### PR TITLE
ICM-139 Fix environment variables race condition

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -316,6 +316,7 @@ define docker::run(
           ensure  => present,
           content => template($docker_version_template),
           mode    => '0755',
+          notify  => Service["${service_prefix}${sanitised_title}"],
         }
       }
 

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -33,18 +33,18 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 <% else %>ExecStartPre=-/usr/bin/<%= @docker_command %> create \
     <%= @docker_run_flags %> \
     --name <%= @sanitised_title %> \
-    ${image} \
+    ${<%= @sanitised_title %>_image} \
     <% if @command %> <%= @command %><% end %>
 <% end -%>
 <% @extra_systemd_parameters.each do |key, value| -%><%= key %>=<%= value %>
 <% end -%>
-<%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull ${image}
+<%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull ${<%= @sanitised_title %>_image}
 <% end -%>
 <%- if @remove_container_on_start %>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <%= @docker_run_flags %> \
         --name <%= @sanitised_title %> \
-        ${image} \
+        ${<%= @sanitised_title %>_image} \
         <% if @command %> <%= @command %><% end %>
 <% else %>
 ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>

--- a/templates/etc/systemd/system/docker-version.erb
+++ b/templates/etc/systemd/system/docker-version.erb
@@ -14,7 +14,7 @@ fi
 
 if [ -n "${image_version}" ]
  then
-  $systemctl_bin set-environment image="${image_name}:${image_version}"
+  $systemctl_bin set-environment <%= @sanitised_title %>_image="${image_name}:${image_version}"
 else
-  $systemctl_bin set-environment image="${image_name}"
+  $systemctl_bin set-environment <%= @sanitised_title %>_image="${image_name}"
 fi


### PR DESCRIPTION
There was a race condition which would spawn Docker containers
with the wrong version or image names due to the fact that the command
`systemctl set-environment` uses the same shared name space for all
systemd.