### PR TITLE
Add 5 seconds to `docker stop` command

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -107,7 +107,7 @@ define docker::run(
   $remove_container_on_stop = true,
   $remove_volume_on_start = false,
   $remove_volume_on_stop = false,
-  $stop_wait_time = 0,
+  $stop_wait_time = 5,
   $syslog_identifier = undef,
 ) {
   include docker::params


### PR DESCRIPTION
In order to fix a problem with ZDD deploys (decsribed in ICM-926), we need to make` docker stop`command wait 5 seconds before sending a SIGKILL. Otherwise, the container would go into a `dead` state, and the next ZDD deploy will fail because there is a container with the same name (in a `dead` state).