### PR TITLE
 Upgrade rake and add lockfile for Dependabot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ doc
 *.swp
 .ruby-version
 log
-Gemfile.lock
 coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rake", "~> 10.0"
+  gem "rake", ">= 12.3.3"
   if puppet_gem_version = ENV['PUPPET_GEM_VERSION']
     gem "puppet", puppet_gem_version
   elsif puppet_git_url = ENV['PUPPET_GIT_URL']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,457 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.6)
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.4.0)
+    ansi (1.5.0)
+    ast (2.4.2)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
+    backports (3.21.0)
+    beaker (2.52.0)
+      aws-sdk-v1 (~> 1.57)
+      beaker-answers (~> 0.0)
+      beaker-hiera (~> 0.0)
+      beaker-hostgenerator
+      beaker-pe (~> 0.0)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25, < 1.35.0)
+      fog-google (~> 0.0.9)
+      google-api-client (~> 0.8, < 0.9.5)
+      hocon (~> 1.0)
+      in-parallel (~> 0.1)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      mime-types (~> 2.99)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
+      public_suffix (< 1.5.0)
+      rbvmomi (~> 1.8, < 1.9.0)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      unf (~> 0.1)
+    beaker-answers (0.29.0)
+      hocon (~> 1.0)
+      require_all (>= 1.3.2, < 3.1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-hiera (0.2.0)
+      stringify-hash (~> 0.0.0)
+    beaker-hostgenerator (1.4.0)
+      deep_merge (~> 1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-pe (0.12.2)
+      stringify-hash (~> 0.0.0)
+    beaker-puppet_install_helper (0.9.4)
+      beaker (>= 2.0)
+    beaker-rspec (5.6.0)
+      beaker (~> 2.0)
+      rspec
+      serverspec (~> 2)
+      specinfra (~> 2)
+    builder (3.2.4)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    deep_merge (1.2.1)
+    diff-lcs (1.4.4)
+    docile (1.4.0)
+    docker-api (2.1.0)
+      excon (>= 0.47.0)
+      multi_json
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dry-inflector (0.2.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
+    excon (0.82.0)
+    facter (2.5.7-universal-darwin)
+      CFPropertyList (~> 2.2)
+    faraday (0.17.4)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.8.0)
+    ffi (1.15.1)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.34.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (2.0.1)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.16.1)
+      dry-inflector
+      fog-core
+      fog-json
+      mime-types
+    fog-core (1.45.0)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.0.9)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-local (0.6.0)
+      fog-core (>= 1.27, < 3.0)
+    fog-powerdns (0.2.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-profitbricks (4.1.1)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
+    gh (0.16.0)
+      activesupport (~> 5.0)
+      addressable (~> 2.4)
+      faraday (~> 0.8)
+      faraday_middleware (~> 0.14)
+      multi_json (~> 1.0)
+      net-http-persistent (~> 2.9)
+      net-http-pipeline
+    google-api-client (0.9.4)
+      addressable (~> 2.3)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+      thor (~> 0.19)
+    googleauth (0.16.2)
+      faraday (>= 0.17.3, < 2.0)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.14)
+    guard (2.17.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-rake (1.0.0)
+      guard
+      rake
+    hiera (3.7.0)
+    highline (1.7.10)
+    hocon (1.3.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    httpclient (2.8.3)
+    hurley (0.2)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    in-parallel (0.1.17)
+    inifile (2.0.2)
+    ipaddress (0.8.3)
+    json (1.8.6)
+    json_pure (2.0.1)
+    jwt (2.2.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    locale (2.1.3)
+    lumberjack (1.2.8)
+    memoist (0.16.2)
+    metadata-json-lint (1.1.0)
+      json
+      semantic_puppet (>= 0.1.2, < 2.0.0)
+      spdx-licenses (~> 1.0)
+    method_source (1.0.0)
+    mime-types (2.99.3)
+    minitar (0.9)
+    minitest (5.14.4)
+    mocha (1.12.0)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
+    nenv (0.3.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.4)
+    net-telnet (0.1.1)
+    netrc (0.11.0)
+    nokogiri (1.11.7-x86_64-darwin)
+      racc (~> 1.4)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    open_uri_redirections (0.2.1)
+    os (1.1.1)
+    parallel (1.20.1)
+    parallel_tests (3.7.0)
+      parallel
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    pathspec (1.0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (1.4.6)
+    puppet (7.7.0-universal-darwin)
+      CFPropertyList (~> 2.2)
+      concurrent-ruby (~> 1.0)
+      deep_merge (~> 1.0)
+      facter (> 2.0.1, < 5)
+      fast_gettext (~> 1.1)
+      hiera (>= 3.2.1, < 4)
+      locale (~> 2.1)
+      multi_json (~> 1.10)
+      puppet-resource_api (~> 1.5)
+      scanf (~> 1.0)
+      semantic_puppet (~> 1.0)
+    puppet-blacksmith (6.1.0)
+      puppet-modulebuilder (~> 0.2)
+      rest-client (~> 2.0)
+    puppet-lint (2.4.2)
+    puppet-lint-unquoted_string-check (2.0.0)
+      puppet-lint (>= 2.1, < 3.0)
+    puppet-modulebuilder (0.3.0)
+      minitar (~> 0.9)
+      pathspec (>= 0.2.1, < 2.0.0)
+    puppet-resource_api (1.8.14)
+      hocon (>= 1.0)
+    puppet-syntax (3.1.0)
+      puppet (>= 5)
+      rake
+    puppetlabs_spec_helper (3.0.0)
+      mocha (~> 1.0)
+      pathspec (>= 0.2.1, < 1.1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (>= 2.0, < 4)
+      rspec-puppet (~> 2.0)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    racc (1.5.2)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rbvmomi (1.8.5)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    regexp_parser (2.1.1)
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    require_all (3.0.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    retriable (2.1.0)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-puppet (2.9.0)
+      rspec
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.10.2)
+    rsync (1.0.9)
+    rubocop (1.16.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.7.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    scanf (1.0.0)
+    semantic_puppet (1.0.4)
+    serverspec (2.41.5)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.72)
+    sfl (2.3)
+    shellany (0.0.1)
+    signet (0.15.0)
+      addressable (~> 2.3)
+      faraday (>= 0.17.3, < 2.0)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-console (0.9.1)
+      ansi
+      simplecov
+      terminal-table
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
+    spdx-licenses (1.3.0)
+    specinfra (2.82.25)
+      net-scp
+      net-ssh (>= 2.7)
+      net-telnet (= 0.1.1)
+      sfl
+    stringify-hash (0.0.2)
+    terminal-table (3.0.1)
+      unicode-display_width (>= 1.1.1, < 3)
+    thor (0.20.3)
+    thread_safe (0.3.6)
+    travis (1.8.13)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    travis-lint (2.0.0)
+      json
+    trollop (2.9.10)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    uber (0.0.15)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+    unicode-display_width (2.0.0)
+    websocket (1.2.9)
+    yard (0.9.26)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  beaker (~> 2.0)
+  beaker-puppet_install_helper
+  beaker-rspec
+  guard-rake
+  json_pure (<= 2.0.1)
+  metadata-json-lint (= 1.1.0)
+  parallel_tests
+  pry
+  puppet
+  puppet-blacksmith
+  puppet-lint
+  puppet-lint-unquoted_string-check
+  puppet-syntax
+  puppetlabs_spec_helper
+  rake (>= 12.3.3)
+  rspec
+  rspec-puppet
+  rspec-retry
+  rubocop
+  simplecov (>= 0.11.0)
+  simplecov-console
+  travis
+  travis-lint
+  yard
+
+BUNDLED WITH
+   2.2.16


### PR DESCRIPTION
This commit upgrades rake from version `13.0.3` and adds the lock
file so that dependabot can open PRs with version upgrades in the
future.